### PR TITLE
Add settings-based greeting popup

### DIFF
--- a/assets/js/components/input_controls.ts
+++ b/assets/js/components/input_controls.ts
@@ -75,6 +75,9 @@ template.innerHTML = String.raw`
       <button title="Open settings menu" id="settings-button" class='button'>
         <span class="fas ${ICONS.settings}"></span>
       </button>
+      <button title="Say hello" id="hello-button" class='button'>
+        Hello
+      </button>
     </div>
   </div>
 `;
@@ -90,6 +93,7 @@ export class InputControls extends HTMLElement {
   private toggleMarkerButton: HTMLButtonElement;
   private chromosomeViewButton: HTMLButtonElement;
   private settingsButton: HTMLButtonElement;
+  private helloButton: HTMLButtonElement;
 
   private searchButton: HTMLButtonElement;
 
@@ -163,6 +167,7 @@ export class InputControls extends HTMLElement {
 
     this.chromosomeViewButton = this.querySelector("#chromosome-view-button");
     this.settingsButton = this.querySelector("#settings-button");
+    this.helloButton = this.querySelector("#hello-button");
 
     this.searchButton = this.querySelector("#search");
 
@@ -172,6 +177,11 @@ export class InputControls extends HTMLElement {
 
     this.settingsButton.addEventListener("click", () => {
       this.onOpenSettings();
+    });
+
+    this.helloButton.addEventListener("click", () => {
+      const name = this.session.getGreetingName();
+      alert(`Hello ${name}`);
     });
 
     // FIXME: Also enter when inside the input?

--- a/assets/js/components/side_menu/settings_menu.ts
+++ b/assets/js/components/side_menu/settings_menu.ts
@@ -103,6 +103,12 @@ template.innerHTML = String.raw`
     </flex-row>
   </flex-row>
   <div id="tracks-overview"></div>
+  <div class="header-row">
+    <div class="header">Greeting name</div>
+  </div>
+  <flex-row class="row">
+    <input id="greeting-input" type="text">
+  </flex-row>
 `;
 
 export class SettingsMenu extends ShadowBaseElement {
@@ -130,6 +136,9 @@ export class SettingsMenu extends ShadowBaseElement {
   private onRemoveSample: (sample: Sample) => void;
   private getTrackHeights: () => TrackHeights;
   private setTrackHeights: (sizes: TrackHeights) => void;
+  private getGreetingName: () => string;
+  private setGreetingName: (name: string) => void;
+  private greetingInput: HTMLInputElement;
 
   public isInitialized: boolean = false;
 
@@ -169,6 +178,8 @@ export class SettingsMenu extends ShadowBaseElement {
 
     this.getTrackHeights = () => session.getTrackHeights();
     this.setTrackHeights = setTrackHeights;
+    this.getGreetingName = () => session.getGreetingName();
+    this.setGreetingName = (name: string) => session.setGreetingName(name);
   }
 
   connectedCallback() {
@@ -189,6 +200,9 @@ export class SettingsMenu extends ShadowBaseElement {
     this.dotTrackExpandedHeightElem = this.root.querySelector(
       "#dot-expanded-height",
     );
+
+    this.greetingInput = this.root.querySelector("#greeting-input");
+    this.greetingInput.value = this.getGreetingName();
 
     const trackSizes = this.getTrackHeights();
 
@@ -230,6 +244,10 @@ export class SettingsMenu extends ShadowBaseElement {
       this.setTrackHeights(myGetTrackHeights());
       this.render({});
     });
+
+    this.addElementListener(this.greetingInput, "input", () => {
+      this.setGreetingName(this.greetingInput.value);
+    });
   }
 
   initialize() {
@@ -243,6 +261,7 @@ export class SettingsMenu extends ShadowBaseElement {
       ),
     );
     this.setupSampleSelect();
+    this.greetingInput.value = this.getGreetingName();
     this.onChange();
   }
 
@@ -307,6 +326,7 @@ export class SettingsMenu extends ShadowBaseElement {
     this.bandTrackCollapsedHeightElem.value = `${bandCollapsed}`;
     this.dotTrackCollapsedHeightElem.value = `${dotCollapsed}`;
     this.dotTrackExpandedHeightElem.value = `${dotExpanded}`;
+    this.greetingInput.value = this.getGreetingName();
   }
 
   getAnnotSources(settings: {

--- a/assets/js/state/gens_session.ts
+++ b/assets/js/state/gens_session.ts
@@ -35,6 +35,7 @@ export class GensSession {
   private gensBaseURL: string;
   private settings: SettingsMenu;
   private genomeBuild: number;
+  private greetingName: string = "World";
 
   constructor(
     // FIXME: This does not belong here I think
@@ -65,6 +66,7 @@ export class GensSession {
     this.gensBaseURL = gensBaseURL;
     this.settings = settings;
     this.genomeBuild = genomeBuild;
+    this.greetingName = "World";
   }
 
   public getGenomeBuild(): number {
@@ -241,5 +243,13 @@ export class GensSession {
   public removeHighlight(id: string) {
     delete this.highlights[id];
     this.render({});
+  }
+
+  public getGreetingName(): string {
+    return this.greetingName;
+  }
+
+  public setGreetingName(name: string) {
+    this.greetingName = name;
   }
 }


### PR DESCRIPTION
## Summary
- allow storing a greeting name in `GensSession`
- add button in input controls to show greeting alert
- expose greeting name input in settings side menu

## Testing
- `npm run typecheck` *(fails: Cannot find name 'expect', etc.)*
- `npm test` *(fails: jest not found)*
- `npx tsc --noEmit` *(fails: Cannot find name 'expect', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684a6d284e148322b1549230cfc4c376