### PR TITLE
Add LDAP direct bind authentication option

### DIFF
--- a/docs/admin_guide/configure_gens.md
+++ b/docs/admin_guide/configure_gens.md
@@ -46,13 +46,12 @@ connection = "mongodb://mongodb:27017/scout"
 [default_profiles]
 "proband+relative" = "profiles/proband_relative.json"
 ```
-
 ## Options
 
 Configuration options. Note that double underscores (`__`) are used to denote sub-categories, such as **gens_db** and **oauth**, when using environment variables. For example, the envionment variable name for configuring Gens mongodb connection is `GENS_DB__CONNECTION` (`<SUB-CATEGORY>__<VARIABLE>`).
 
 - **scout_url**, base url to Scout.
-- **authentication**, authentication method "oauth", "simple", "disabled"
+- **authentication**, authentication method "oauth", "ldap", "simple", "disabled"
 - **default_annotation_track**, when opening a fresh browser, this track will be preselected. Selected annotation tracks are now stored in the browser session, so if the user changes tracks that choice will persist.
 - **main_sample_types**, sample types handled as the "main" sample for multi-sample cases. I.e. the sample displayed in the overview plot and multi-chromosome view.
 - **default_profiles**, mapping from profile type to default profile JSON. Profile types are calculated by the unique and sorted `sample_type` values joined by `+`. Values are paths to JSON files relative to the config file.
@@ -66,4 +65,9 @@ Configuration options. Note that double underscores (`__`) are used to denote su
 
 - **connection**, mongodb conneciton string
 - **database**, optional database name. Can also be in connection string
+
+**ldap**
+
+- **server**, LDAP server URL such as `ldap://ldap.example.com`
+- **bind_user_template**, template used to bind directly to the LDAP server. Include `{username}` where the supplied username or email should be inserted, e.g. `uid={username},ou=People,dc=example,dc=com`
 

--- a/gens/blueprints/home/templates/landing.html
+++ b/gens/blueprints/home/templates/landing.html
@@ -31,10 +31,24 @@
   </p>
   {% if current_user and current_user.is_authenticated %}
     <a class="btn" href="{{ url_for('home.home') }}">Welcome to GENS {{ current_user.name }}!</a>
-  {% elif config.GOOGLE %}
+  {% elif authentication.value == 'oauth' %}
         <a class="btn" href="{{ url_for('login.login') }}" role="button">
           Login with Google
         </a>
+  {% elif authentication.value == 'ldap' %}
+    <form method="POST" action="{{ url_for('login.login') }}">
+    <ul>
+      <li>
+       <input type="text" placeholder="email" class="form-control" name="email">
+     </li>
+     <li>
+       <input type="password" placeholder="password" class="form-control" name="password">
+     </li>
+     <li>
+       <button type="submit" class="btn">Login</button>
+     </li>
+    </ul>
+    </form>
   {% else %}
     <form method="POST" action="{{ url_for('login.login') }}">
     <ul>

--- a/gens/blueprints/home/views.py
+++ b/gens/blueprints/home/views.py
@@ -96,5 +96,6 @@ def landing() -> str:
 
     return render_template(
         "landing.html",
+        authentication=settings.authentication,
         version=version,
     )

--- a/gens/blueprints/login/views.py
+++ b/gens/blueprints/login/views.py
@@ -5,11 +5,13 @@ from typing import Any
 
 from flask import Blueprint, current_app, flash, redirect, request, session, url_for
 from flask_login import login_user, logout_user
+from ldap3 import Connection, Server
+from ldap3.core.exceptions import LDAPException
 from pymongo.database import Database
 from werkzeug.wrappers.response import Response
 
 from gens.auth import LoginUser, login_manager, oauth_client
-from gens.config import AuthMethod, settings
+from gens.config import AuthMethod, LdapConfig, settings
 from gens.crud.user import get_user
 from gens.db.collections import USER_COLLECTION
 
@@ -18,6 +20,34 @@ from ..home.views import public_endpoint
 # from . import controllers
 
 LOG = logging.getLogger(__name__)
+
+
+def authenticate_with_ldap(
+    username: str, password: str, ldap_config: LdapConfig | None = None
+) -> bool:
+    """Authenticate a user using LDAP direct bind."""
+
+    configuration = ldap_config or settings.ldap
+    if configuration is None:
+        LOG.warning("LDAP authentication requested but no LDAP config is present")
+        return False
+
+    try:
+        bind_dn = configuration.bind_user_template.format(username=username)
+    except KeyError as error:
+        LOG.error("Failed to format LDAP bind DN: missing %s", error)
+        return False
+    server = Server(str(configuration.server))
+
+    try:
+        with Connection(
+            server, user=bind_dn, password=password, auto_bind=True
+        ) as connection:
+            return connection.bound
+    except LDAPException as error:
+        LOG.warning("LDAP authentication failed for %s", username)
+        LOG.debug("LDAP exception: %s", error)
+    return False
 
 
 @login_manager.user_loader
@@ -53,6 +83,7 @@ def login() -> Response:
     if "next" in request.args:
         session["next_url"] = request.args["next"]
 
+    user_mail: str | None = None
     if settings.authentication == AuthMethod.OAUTH:
         if session.get("email"):
             user_mail = session["email"]
@@ -67,9 +98,29 @@ def login() -> Response:
                 LOG.error("An error occurred while trying use OAUTH - %s", error)
                 flash("An error has occurred while logging user in using Google OAuth")
 
-    if request.form.get("email"):  # Log in against Scout database
+    elif request.method == "POST":
         user_mail = request.form.get("email")
+        if not user_mail:
+            flash("Please enter an email", "warning")
+            return redirect(url_for("home.landing"))
+
+        if settings.authentication == AuthMethod.LDAP:
+            password = request.form.get("password")
+            if not password:
+                flash("Please enter both email and password", "warning")
+                return redirect(url_for("home.landing"))
+
+            if not authenticate_with_ldap(user_mail, password):
+                flash("Incorrect username or password", "warning")
+                return redirect(url_for("home.landing"))
+
         LOG.info("Validating user %s against Scout database", user_mail)
+    else:
+        return redirect(url_for("home.landing"))
+
+    if user_mail is None:
+        flash("Unable to log in with the provided credentials", "warning")
+        return redirect(url_for("home.landing"))
 
     db: Database[Any] = current_app.config["GENS_DB"]
     user_col = db.get_collection(USER_COLLECTION)

--- a/gens/config.py
+++ b/gens/config.py
@@ -6,7 +6,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Literal, Tuple, Type
 
-from pydantic import BaseModel, Field, HttpUrl, MongoDsn, model_validator
+from pydantic import AnyUrl, BaseModel, Field, HttpUrl, MongoDsn, model_validator
 from pydantic_settings import (
     BaseSettings,
     PydanticBaseSettingsSource,
@@ -33,6 +33,7 @@ class AuthMethod(Enum):
     """Valid authentication options"""
 
     OAUTH = "oauth"
+    LDAP = "ldap"
     SIMPLE = "simple"
     DISABLED = "disabled"
 
@@ -43,6 +44,19 @@ class OauthConfig(BaseSettings):
     client_id: str
     secret: str
     discovery_url: HttpUrl
+
+
+class LdapConfig(BaseSettings):
+    """Configuration for LDAP direct bind authentication."""
+
+    server: AnyUrl = Field(..., description="LDAP server URL, e.g. ldap://ldap")
+    bind_user_template: str = Field(
+        default="{username}",
+        description=(
+            "Template used to build the bind DN. "
+            "The placeholder '{username}' will be replaced with the provided username."
+        ),
+    )
 
 
 class MongoDbConfig(BaseSettings):
@@ -93,6 +107,9 @@ class Settings(BaseSettings):
     # Oauth options
     oauth: OauthConfig | None = None
 
+    # LDAP options
+    ldap: LdapConfig | None = None
+
     model_config = SettingsConfigDict(
         env_file_encoding="utf-8",
         toml_file=config_file,
@@ -118,6 +135,7 @@ class Settings(BaseSettings):
             "main_sample_types": self.main_sample_types,
             "authentication": self.authentication.value,
             "oauth": self.oauth,
+            "ldap": self.ldap,
             "default_profiles": self.default_profiles,
             "warning_thresholds": [
                 threshold.model_dump() for threshold in self.warning_thresholds
@@ -127,11 +145,15 @@ class Settings(BaseSettings):
     @model_validator(mode="after")
     def check_oauth_opts(self) -> "Settings":
         """Check that OAUTH options are set if authentication is oauth."""
-        if self.authentication == AuthMethod.OAUTH:
-            if self.oauth is None:
-                raise ValueError(
-                    "OAUTH require you to configure client_id, secret and discovery_url"
-                )
+        if self.authentication == AuthMethod.OAUTH and self.oauth is None:
+            raise ValueError(
+                "OAUTH require you to configure client_id, secret and discovery_url"
+            )
+
+        if self.authentication == AuthMethod.LDAP and self.ldap is None:
+            raise ValueError(
+                "LDAP authentication requires you to configure server and bind_user_template"
+            )
         return self
 
     @model_validator(mode="after")

--- a/gens/config.toml
+++ b/gens/config.toml
@@ -35,3 +35,8 @@ kind = "threshold_above"
 size = 200
 message = "Exceeds max mismatch count"
 
+# Example LDAP authentication configuration
+#[ldap]
+#server = "ldap://ldap.example.com"
+#bind_user_template = "uid={username},ou=People,dc=example,dc=com"
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
   "Flask",
   "flask_login",
   "authlib",
+  "ldap3",
   "pymongo",
   "pysam",
   "fastapi",

--- a/tests/test_ldap_auth.py
+++ b/tests/test_ldap_auth.py
@@ -1,0 +1,60 @@
+"""Tests for LDAP authentication helper."""
+
+from typing import Dict
+
+from ldap3.core.exceptions import LDAPException
+
+from gens.blueprints.login.views import authenticate_with_ldap
+from gens.config import LdapConfig
+
+
+def test_authenticate_with_ldap_builds_bind_dn(monkeypatch):
+    calls: Dict[str, str] = {}
+
+    class DummyServer:
+        def __init__(self, url: str):
+            calls["server"] = url
+
+    class DummyConnection:
+        def __init__(self, server: DummyServer, user: str, password: str, auto_bind: bool):
+            calls["user"] = user
+            calls["password"] = password
+
+        def __enter__(self) -> "DummyConnection":
+            self.bound = True
+            return self
+
+        def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+            return None
+
+    monkeypatch.setattr("gens.blueprints.login.views.Server", DummyServer)
+    monkeypatch.setattr("gens.blueprints.login.views.Connection", DummyConnection)
+
+    ldap_config = LdapConfig(
+        server="ldap://ldap.example.com",
+        bind_user_template="uid={username},ou=People,dc=example,dc=com",
+    )
+
+    assert authenticate_with_ldap("alice", "hunter2", ldap_config) is True
+    assert calls["user"] == "uid=alice,ou=People,dc=example,dc=com"
+    assert calls["server"] == "ldap://ldap.example.com"
+
+
+def test_authenticate_with_ldap_handles_ldap_exception(monkeypatch):
+    class DummyServer:
+        def __init__(self, url: str):
+            self.url = url
+
+    class CustomLDAPException(LDAPException):
+        pass
+
+    class FailingConnection:
+        def __init__(self, *args, **kwargs):
+            raise CustomLDAPException("bind failed")
+
+    monkeypatch.setattr("gens.blueprints.login.views.Server", DummyServer)
+    monkeypatch.setattr("gens.blueprints.login.views.Connection", FailingConnection)
+
+    ldap_config = LdapConfig(server="ldap://ldap.example.com")
+
+    assert authenticate_with_ldap("alice", "hunter2", ldap_config) is False


### PR DESCRIPTION
## Summary
- add an LDAP authentication method with configurable direct-bind templates and landing page password form
- implement LDAP bind helper with tests and validate configuration requirements
- document LDAP settings and update example configuration and dependencies

## Testing
- pytest -q *(fails: ModuleNotFoundError: No module named 'mongomock' in the current environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69371cc62bfc832297b13fac802930a1)